### PR TITLE
Update electron-builder.json

### DIFF
--- a/Breeze.UI/electron-builder.json
+++ b/Breeze.UI/electron-builder.json
@@ -6,7 +6,7 @@
   },
   "directories": {
       "app": "dist",
-      "output": "app-builds"
+      "output": "app-builds",
       "buildResources": "dist/assets/images"
   },
   "win": {

--- a/Breeze.UI/electron-builder.json
+++ b/Breeze.UI/electron-builder.json
@@ -7,9 +7,10 @@
   "directories": {
       "app": "dist",
       "output": "app-builds"
+      "buildResources": "dist/assets/images"
   },
   "win": {
-      "icon": "dist/assets/images/breeze-logo",
+      "icon": "dist/assets/images",
       "target": ["nsis"]
   },
   "linux": {


### PR DESCRIPTION
Provide correct path to build icons. The path must be a directory and not pointed to a filename.